### PR TITLE
修复luguohuakai\db\dm\Schem的createQueryBuilder方法创建的不是luguohuakai\db\dm\…

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -77,7 +77,7 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     public function createQueryBuilder()
     {
-        return new QueryBuilder($this->db);
+        return new \luguohuakai\db\dm\QueryBuilder($this->db);
     }
 
     /**


### PR DESCRIPTION
…QueryBuilder类而是yii\db\QueryBuilder类，导致luguohuakai\db\dm\QueryBuilder类的方法无法正确使用